### PR TITLE
Enable trailing commas in PLAYTOMIC_FORMAT

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
@@ -47,7 +47,7 @@ object Formatter {
       FormattingOptions(
           blockIndent = 4,
           continuationIndent = 4,
-          manageTrailingCommas = false,
+          manageTrailingCommas = true,
           maxWidth = 180,
       )
 


### PR DESCRIPTION
## Summary

Flip `manageTrailingCommas` to `true` in the `PLAYTOMIC_FORMAT` preset so the formatter adds trailing commas to multi-line declarations.

This aligns the Playtomic style with:
- [Kotlin's official coding conventions](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas)
- Android Studio's default behavior (recent versions add trailing commas automatically)

## Changes

- `core/src/main/java/com/facebook/ktfmt/format/Formatter.kt` — set `manageTrailingCommas = true` in `PLAYTOMIC_FORMAT`
- `artifact/ktfmt-playtomic.jar` — rebuilt from this change so the published artifact reflects the new behavior

## Verification

`javap` on the rebuilt jar confirms `PLAYTOMIC_FORMAT` now has `manageTrailingCommas = true`:

```
14: sipush  180
17: iconst_4   // blockIndent
18: iconst_4   // continuationIndent
19: iconst_1   // manageTrailingCommas (was iconst_0)
20: iconst_0
21: iconst_0
```

Companion PR in `syltek/playtomic-android` that applies the bulk reformat will be opened once this lands and the artifact is republished, so CI on that PR pulls the updated jar.